### PR TITLE
Add port mapping to docker compose

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -3,6 +3,8 @@ services:
   web:
     image: metikular/coupon-store
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 80 -b '0.0.0.0'"
+    ports:
+      - 80:80
     depends_on:
       - db
     environment:


### PR DESCRIPTION
Many people like to run multiple services on a single host machine. By providing a port mapping, the user can change the host port like:
```
ports:
  - 10037:80
```